### PR TITLE
Add the card holder name property for 3DS V2

### DIFF
--- a/src/Model/Card/Card.php
+++ b/src/Model/Card/Card.php
@@ -90,6 +90,11 @@ class Card implements BaseModelInterface
     private $createdAt;
 
     /**
+     * @var string
+     */
+    private $cardHolderName;
+
+    /**
      * Card constructor.
      *
      * @param string|null $jsonData
@@ -269,6 +274,22 @@ class Card implements BaseModelInterface
     }
 
     /**
+     * @return string|null
+     */
+    public function getCardHolderName()
+    {
+        return $this->cardHolderName;
+    }
+
+    /**
+     * @param string $cardHolderName
+     */
+    public function setCardHolderName(string $cardHolderName)
+    {
+        $this->cardHolderName = $cardHolderName;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function httpCreate(): array
@@ -278,6 +299,7 @@ class Card implements BaseModelInterface
             'token'           => $this->token,
             'label'           => $this->label,
             'tag'             => $this->tag,
+            'cardHolderName'  => $this->cardHolderName,
         ];
     }
 

--- a/src/Model/Card/RegisterCard.php
+++ b/src/Model/Card/RegisterCard.php
@@ -80,6 +80,11 @@ class RegisterCard implements BaseModelInterface
     private $createdAt;
 
     /**
+     * @var string
+     */
+    private $cardHolderName;
+
+    /**
      * Card constructor.
      *
      * @param string|null $jsonData
@@ -243,6 +248,22 @@ class RegisterCard implements BaseModelInterface
     }
 
     /**
+     * @return string|null
+     */
+    public function getCardHolderName()
+    {
+        return $this->cardHolderName;
+    }
+
+    /**
+     * @param string $cardHolderName
+     */
+    public function setCardHolderName(string $cardHolderName)
+    {
+        $this->cardHolderName = $cardHolderName;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function httpCreate(): array
@@ -253,6 +274,7 @@ class RegisterCard implements BaseModelInterface
             'receiptId'       => $this->receiptId,
             'label'           => $this->label,
             'tag'             => $this->tag,
+            'cardHolderName'  => $this->cardHolderName,
         ];
     }
 


### PR DESCRIPTION
Starting from now we need to collect the card holder name for every new card registration. This is needed for the 3DS V2.