### PR TITLE
Delete the cardHolderName for new cards

### DIFF
--- a/src/Model/Card/RegisterCard.php
+++ b/src/Model/Card/RegisterCard.php
@@ -80,11 +80,6 @@ class RegisterCard implements BaseModelInterface
     private $createdAt;
 
     /**
-     * @var string
-     */
-    private $cardHolderName;
-
-    /**
      * Card constructor.
      *
      * @param string|null $jsonData
@@ -248,22 +243,6 @@ class RegisterCard implements BaseModelInterface
     }
 
     /**
-     * @return string|null
-     */
-    public function getCardHolderName()
-    {
-        return $this->cardHolderName;
-    }
-
-    /**
-     * @param string $cardHolderName
-     */
-    public function setCardHolderName(string $cardHolderName)
-    {
-        $this->cardHolderName = $cardHolderName;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function httpCreate(): array
@@ -274,7 +253,6 @@ class RegisterCard implements BaseModelInterface
             'receiptId'       => $this->receiptId,
             'label'           => $this->label,
             'tag'             => $this->tag,
-            'cardHolderName'  => $this->cardHolderName,
         ];
     }
 


### PR DESCRIPTION
Exactly as the name says: we delete the cardHolderName added previously as we don't need it anymore for new cards.